### PR TITLE
Update the Go installation to v1.13.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
     bash /root/install-nvm.sh && \
     rm /root/install-nvm.sh
 
-RUN curl -L "https://dl.google.com/go/go1.12.linux-amd64.tar.gz" -o /root/go1.12.linux-amd64.tgz && \
-    tar -C /usr/local -xzf /root/go1.12.linux-amd64.tgz
+RUN curl -L "https://dl.google.com/go/go1.13.5.linux-amd64.tar.gz" -o /root/go1.13.5.linux-amd64.tgz && \
+    tar -C /usr/local -xzf /root/go1.13.5.linux-amd64.tgz
 
 ENV PATH="${PATH}:/usr/local/go/bin"
 


### PR DESCRIPTION
We've tested the fleet CI image against the tag on this branch.  It works so we are ready to:

1. merge this into master
2. tag in with the next 0.X.0 number

Thanks